### PR TITLE
ci(dependabot): ignore parallel semver-major bumps

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,3 +10,6 @@ updates:
     allow:
       - dependency-type: direct
       - dependency-type: indirect
+    ignore:
+      - dependency-name: parallel
+        update-types: ["version-update:semver-major"]


### PR DESCRIPTION
## Summary
- parallel >= 2.0 requires Ruby >= 3.3, but our CI matrix still includes Ruby 3.1.7 / 3.2.8
- Dependabot's resolver crashes on every run while trying to bump parallel from 1.28.0, blocking all other dependency PRs
- Add a `version-update:semver-major` ignore so Dependabot stops trying

Closes unhappychoice/oss-issue-opener#222

## Test plan
- [ ] Next Dependabot run completes without the parallel resolver crash